### PR TITLE
scripts: do not escape accents in pathnames

### DIFF
--- a/bin/extract-json-file.sh
+++ b/bin/extract-json-file.sh
@@ -9,6 +9,8 @@ commit="$1"
 branch="origin/hugo-site"
 pattern="posts/*/index.json"
 
+# core.quotepath defaults to 'true' which quotes and escapes "unusual" characters in the pathname (accents included)
+git config --local core.quotepath false
 json_post=$(git diff-tree --no-commit-id --name-only --diff-filter=A -r "$commit" -- "$pattern")
 git checkout "$branch" -- "$json_post"
 echo "$json_post"


### PR DESCRIPTION
```
$ git ls-files
"vid\303\251o"
$ git config --local core.quotepath false
$ git ls-files
vidéo
```

Closes: https://github.com/sre-france/antenna/issues/10
Signed-off-by: Mathieu Tortuyaux <mathieu.tortuyaux@gmail.com>